### PR TITLE
feat: Upgrade to MobX 4.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -327,9 +327,9 @@
       }
     },
     "@semantic-release/release-notes-generator": {
-      "version": "6.0.9",
-      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-6.0.9.tgz",
-      "integrity": "sha512-qK9d4m4QoK5kqZ/QU0hwDIdaIj0FttsActLAAH87FrqJYJZCikMrgrpzkLM8YFpgi6MZCew9YirGVrwvmxXUVg==",
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-6.0.10.tgz",
+      "integrity": "sha512-8eigxfGSy36+mv4rUIbGZAGZkUVZYNXOyRpcG+ZHSeGTqG6hu9uUxmzkfQ2hvK3zSxqrzKPg3MxnhvZL1Qqmrg==",
       "dev": true,
       "requires": {
         "conventional-changelog-angular": "3.0.6",
@@ -337,7 +337,7 @@
         "conventional-commits-parser": "2.1.7",
         "debug": "3.1.0",
         "get-stream": "3.0.0",
-        "git-url-parse": "8.3.1",
+        "git-url-parse": "9.0.0",
         "import-from": "2.1.0",
         "into-stream": "3.1.0",
         "lodash": "4.17.5"
@@ -4420,9 +4420,9 @@
       }
     },
     "git-url-parse": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-8.3.1.tgz",
-      "integrity": "sha512-r/FxXIdfgdSO+V2zl4ZK1JGYkHT9nqVRSzom5WsYPLg3XzeBeKPl3R/6X9E9ZJRx/sE/dXwXtfl+Zp7YL8ktWQ==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-9.0.0.tgz",
+      "integrity": "sha512-zks1jS4ocMA/9WUx3C0nGIj/wBQjjIuktQ4KqKTyStMdEtnnFbZ4ZVKCvNeHwKh1COk/8sZaVTyvYj3paHI9Fg==",
       "dev": true,
       "requires": {
         "git-up": "2.0.10",
@@ -7366,15 +7366,15 @@
       }
     },
     "mobx": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/mobx/-/mobx-3.5.1.tgz",
-      "integrity": "sha1-jmguxTXPROBABbnjfi32asyXWkI=",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/mobx/-/mobx-4.1.1.tgz",
+      "integrity": "sha1-fOfvkrIuhScdH8J0oSTX+jL8zus=",
       "dev": true
     },
     "mobx-react": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/mobx-react/-/mobx-react-4.4.1.tgz",
-      "integrity": "sha1-fMeTtVu7dIXx/r0YwZE8WBwSTtw=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/mobx-react/-/mobx-react-5.0.0.tgz",
+      "integrity": "sha1-jVozvjdvoisYSm9VXUCmo6hFmhY=",
       "dev": true,
       "requires": {
         "hoist-non-react-statics": "2.5.0"
@@ -9236,16 +9236,16 @@
       "dev": true
     },
     "semantic-release": {
-      "version": "15.1.6",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-15.1.6.tgz",
-      "integrity": "sha512-l9q8aOPfNm/ioUTzUKj5hhsed8S5o10/YWHWkfoN7QghMmgg1GD3YD3efYCk9EzztS/K1yxRqBlaxhHJCAWzUQ==",
+      "version": "15.1.7",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-15.1.7.tgz",
+      "integrity": "sha512-ovMwzP7dTL3r61xKJE6tY0PI+W/oPNyCzFdRkxk8ep4EVByOkRkycZ1A0XOEEEsqQKGAhNubt7fFwQG7G18yzg==",
       "dev": true,
       "requires": {
         "@semantic-release/commit-analyzer": "5.0.3",
         "@semantic-release/error": "2.2.0",
         "@semantic-release/github": "4.2.11",
         "@semantic-release/npm": "3.2.4",
-        "@semantic-release/release-notes-generator": "6.0.9",
+        "@semantic-release/release-notes-generator": "6.0.10",
         "aggregate-error": "1.0.0",
         "chalk": "2.3.2",
         "cosmiconfig": "4.0.0",
@@ -9254,7 +9254,7 @@
         "execa": "0.10.0",
         "get-stream": "3.0.0",
         "git-log-parser": "1.2.0",
-        "git-url-parse": "8.3.1",
+        "git-url-parse": "9.0.0",
         "hook-std": "0.4.0",
         "hosted-git-info": "2.6.0",
         "lodash": "4.17.5",

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
   "peerDependencies": {
     "history": "^4.x",
     "react": "16.x",
-    "mobx": "^3.x",
-    "mobx-react": "^4.x"
+    "mobx": "^4.x",
+    "mobx-react": "^5.x"
   },
   "devDependencies": {
     "@types/enzyme": "^3.1.9",
@@ -66,15 +66,15 @@
     "jest": "^22.4.3",
     "lint-staged": "^7.0.4",
     "lodash.camelcase": "^4.3.0",
-    "mobx": "3.5.1",
-    "mobx-react": "4.4.1",
+    "mobx": "4.1.1",
+    "mobx-react": "5.0.0",
     "prettier": "^1.12.0",
     "prompt": "^1.0.0",
     "react": "^16.3.1",
     "react-dom": "^16.3.1",
     "replace-in-file": "^3.4.0",
     "rimraf": "^2.6.1",
-    "semantic-release": "^15.1.6",
+    "semantic-release": "^15.1.7",
     "ts-jest": "^22.4.2",
     "ts-node": "^5.0.1",
     "tslint": "^5.9.1",


### PR DESCRIPTION
This release upgrades the dependency from MobX 3.x to MobX 4.x. If you are using MobX 3.x in your
application, then you should not upgrade to release. Stick with mobx-state-router 2.x.

BREAKING CHANGE: This release will not work with MobX 3.x. You must upgrade your application to MobX
4.x to use this release.

fix #15