### PR TITLE
Relaxing RouterLink interface

### DIFF
--- a/src/components/router-link.tsx
+++ b/src/components/router-link.tsx
@@ -12,7 +12,7 @@ function isModifiedEvent(event: React.MouseEvent<HTMLElement>) {
 }
 
 export interface RouterLinkProps {
-    rootStore: any;
+    rootStore?: any;
     routeName: string;
     params?: StringMap;
     queryParams?: Object;


### PR DESCRIPTION
In order to make the `rootStore` truly optional the interface is relaxed.
(for more info see here: https://github.com/mobxjs/mobx-react/issues/256)