### PR TITLE
Links are now re-rendered on state change

### DIFF
--- a/src/components/router-link.tsx
+++ b/src/components/router-link.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { inject } from 'mobx-react';
+import { inject, observer } from 'mobx-react';
 import { RouterState, StringMap } from '../router-store';
 import { routerStateToUrl } from '../adapters/generate-url';
 
@@ -42,6 +42,7 @@ export interface RouterLinkProps {
  * useful for highlighting the active link in a navbar.
  */
 @inject('rootStore')
+@observer
 export class RouterLink extends React.Component<RouterLinkProps, {}> {
     render() {
         const {


### PR DESCRIPTION
Added a missing observer annotation to allow the RouterLink to re-render when state changes. This is needed in order for the active link class to work.