### PR TITLE
fix(history-adapter): add Object.prototype for query-string parse result

### DIFF
--- a/src/@types/value-equal.d.ts
+++ b/src/@types/value-equal.d.ts
@@ -1,3 +1,3 @@
 declare module 'value-equal' {
-    export default function valueEqual(a: any, b: any): boolean;
+    export default function(a: any, b: any): boolean;
 }

--- a/src/adapters/history-adapter.ts
+++ b/src/adapters/history-adapter.ts
@@ -50,7 +50,8 @@ export class HistoryAdapter {
                 new RouterState(
                     matchingRoute.name,
                     params,
-                    parse(location.search)
+                    // for fix https://github.com/mjackson/value-equal/issues/10
+                    Object.assign({}, parse(location.search))
                 )
             );
         } else {
@@ -65,7 +66,7 @@ export class HistoryAdapter {
     observeRouterStateChanges = () => {
         reaction(
             () => this.routerStore.routerState,
-            routerState => {
+            (routerState: RouterState) => {
                 const location = this.history.location;
                 const currentUrl = `${location.pathname}${location.search}`;
                 const routerStateUrl = routerStateToUrl(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "allowSyntheticDefaultImports": true,
+        "esModuleInterop": true,
         "declaration": true,
         "declarationDir": "dist/types",
         "experimentalDecorators": true,


### PR DESCRIPTION
add compiler option esModuleInterop instead allowSyntheticDefaultImports

fix #28