### PR TITLE
feat(links.tsx): Pass props to anchor element and handle onClick event

### DIFF
--- a/src/components/link.tsx
+++ b/src/components/link.tsx
@@ -10,7 +10,8 @@ function isModifiedEvent(event: React.MouseEvent<HTMLElement>) {
     return event.metaKey || event.altKey || event.ctrlKey || event.shiftKey;
 }
 
-export interface LinkProps {
+export interface LinkProps
+    extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
     routerStore: RouterStore;
     toState: RouterState;
     className?: string;
@@ -43,7 +44,10 @@ export class Link extends React.Component<LinkProps, {}> {
             toState,
             className,
             activeClassName,
-            children
+            children,
+            onClick, // for remove `onClick` out of `...others`
+            href, // for remove `href` out of `...others`
+            ...others
         } = this.props;
 
         const isActive = routerStore.routerState.isEqual(toState);
@@ -53,6 +57,7 @@ export class Link extends React.Component<LinkProps, {}> {
 
         return (
             <a
+                {...others}
                 className={joinedClassName}
                 href={routerStateToUrl(routerStore, toState)}
                 onClick={this.handleClick}
@@ -62,7 +67,7 @@ export class Link extends React.Component<LinkProps, {}> {
         );
     }
 
-    handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
         // Ignore if link is clicked using a modifier key or not left-clicked
         if (isModifiedEvent(event) || !isLeftClickEvent(event)) {
             return undefined;
@@ -72,7 +77,8 @@ export class Link extends React.Component<LinkProps, {}> {
         event.preventDefault();
 
         // Change the router state to trigger a refresh
-        const { routerStore, toState } = this.props;
+        const { routerStore, toState, onClick } = this.props;
+        if (onClick != null) onClick(event);
         return routerStore.goTo(toState);
     };
 }

--- a/test/link.test.tsx
+++ b/test/link.test.tsx
@@ -139,7 +139,6 @@ describe('RouterLink', () => {
         // jest.runAllTimers();
     });
 
-    /*
     // Uncomment this test to see the issue with PR-41
     test('calls onClick prop when passed in', () => {
         const mockCallBack = jest.fn();
@@ -157,5 +156,4 @@ describe('RouterLink', () => {
         wrapper.find('a').simulate('click', { button: 0 });
         expect(mockCallBack.mock.calls.length).toEqual(1);
     });
-    */
 });


### PR DESCRIPTION
This PR allow to

- pass other `props` from `<Link>` to the under `<a>` element.
- handle `onClick` event

```jsx
<Link onClick={handleClick} onFocus={handleFocus} />
```