### PR TITLE
feat: Added helpers for server-side rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,6 +453,12 @@ export interface Route {
 The `RouterStore` is the keeper of the `RouterState`. It allows transitioning between states using the `goTo()` method.
 
 ```jsx
+export interface JsRouterState {
+    routeName: string;
+    params?: StringMap;
+    queryParams?: Object;
+}
+
 export interface ErrorHook {
     (err: Error): any;
 }
@@ -461,7 +467,9 @@ export class RouterStore {
     @observable.ref routerState: RouterState;
     @observable isTransitioning: boolean = false;
 
-    constructor(rootStore: any, routes: Route[], notFoundState: RouterState, initialRoute: Route = INITIAL_ROUTE);
+    constructor(rootStore: any, routes: Route[], notFoundState: RouterState, initialState?: JsRouterState);
+    hydrate(state: JsRouterState);
+    serialize(): JsRouterState;
     setErrorHook(onError: ErrorHook);
     goTo(toState: RouterState): Promise<RouterState>;
     goTo(routeName: string, params?: StringMap, queryParams?: Object): Promise<RouterState>;
@@ -478,6 +486,8 @@ The `RouterStore` exposes two observable properties:
 - isTransitioning: set to true when the router is in the process of transitioning from one state to another. This property can be used, for example, to display a progress indicator during transitions.
 
 The `RouterStore` allows you to set a custom error hook using the `setErrorHook()` method. This hook is called if any unexpected error occurs when transitioning states. You can set this hook, for example, to transition to an error page.
+
+The `serialize()` method serializes the state of the router to a plain JavaScript object. The `hydrate()` method does the reverse - it initializes the router using a plain JavaScript object. These methods are useful in server-side rendering. 
 
 ### HistoryAdapter
 The `HistoryAdapter` is responsible for keeping the browser address bar and the `RouterState` in sync. It also provides a `goBack()` method to go back in history.

--- a/test/router-store.test.ts
+++ b/test/router-store.test.ts
@@ -216,9 +216,8 @@ describe('RouterStore', () => {
     });
 
     test('allows to set a specific initial route', () => {
-        const initialRoute = {
-            name: 'home',
-            pattern: '/'
+        const initialState = {
+            routeName: 'home'
         };
 
         const expectedRouterState = {
@@ -226,16 +225,51 @@ describe('RouterStore', () => {
             params: {},
             queryParams: {}
         };
-        const routerStore = new RouterStore({}, routes, notFound, initialRoute);
+        const routerStore = new RouterStore({}, routes, notFound, initialState);
         expect(routerStore.routerState).toMatchObject(expectedRouterState);
     });
 
     test('allows to query the current route', () => {
-        const initialRoute = {
+        const initialState = {
+            routeName: 'home'
+        };
+
+        const expectedRoute = {
             name: 'home',
             pattern: '/'
         };
-        const routerStore = new RouterStore({}, routes, notFound, initialRoute);
-        expect(routerStore.getCurrentRoute()).toMatchObject(initialRoute);
+        const routerStore = new RouterStore({}, routes, notFound, initialState);
+        expect(routerStore.getCurrentRoute()).toMatchObject(expectedRoute);
+    });
+
+    test('allows to hydrate from a serialized state', () => {
+        const serverState = {
+            routeName: 'home'
+        };
+
+        const expectedRouterState = {
+            routeName: 'home',
+            params: {},
+            queryParams: {}
+        };
+        const routerStore = new RouterStore({}, routes, notFound);
+        routerStore.hydrate(serverState);
+        expect(routerStore.routerState).toMatchObject(expectedRouterState);
+    });
+
+    test('allows to serialize current state', () => {
+        const expectedSerializedState = {
+            routeName: 'department',
+            params: { id: 'electronics' },
+            queryParams: {}
+        };
+
+        const routerStore = new RouterStore(
+            {},
+            routes,
+            notFound,
+            deptElectronics
+        );
+        expect(routerStore.serialize()).toMatchObject(expectedSerializedState);
     });
 });


### PR DESCRIPTION
Added methods to serialize and hydrate the state of the router.

BREAKING CHANGE: The `RouterStore` constructor has a small change in its arguments - the last
argument `initialRoute` is replaced by `initialState`. This argument was seldom used, so it should
not affect most users. The new signature now supports hydration from the state provided by the
server.