### PR TITLE
BREAKING CHANGE: React-router like route configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,18 +116,24 @@ Now let's define our routes, the `RouterStore` will need them. By convention we 
 // one or more parameters). For example:
 //     /items
 //     /items/:id
+import HomeComponent from './src/features/Home';
+import DepartmentComponent from './src/features/Department';
+
 export const routes = [
     {
         name: 'home',
-        pattern: '/'
+        pattern: '/',
+        component: HomeComponent
     },
     {
         name: 'department',
-        pattern: '/departments/:id'
+        pattern: '/departments/:id',
+        component: DepartmentComponent 
     },
     {
         name: 'notFound',
-        pattern: '/not-found'
+        pattern: '/not-found',
+        component: <h1>404 Page not found</h1>
     }
 ];
 ```
@@ -193,19 +199,13 @@ import { DepartmentPage } from './features/department/department-page';
 import { HomePage } from './features/home/home-page';
 import { NotFoundPage } from './features/not-found-page';
 
-const viewMap = {
-    department: <DepartmentPage />,
-    home: <HomePage />,
-    notFound: <NotFoundPage />
-};
-
 class ShellBase extends React.Component {
     render() {
         const { rootStore: { routerStore } } = this.props;
 
         return (
             <div>
-                <RouterView routerStore={routerStore} viewMap={viewMap} />
+                <RouterView routerStore={routerStore} />
             </div>
         );
     }
@@ -214,7 +214,7 @@ class ShellBase extends React.Component {
 export const Shell = inject('rootStore')(ShellBase);
 ```
 
-Here we instantiate the `RouterView` in the `render()` method. We supply the `routerStore` as a prop along with a `viewMap`. The `RouterView` uses the `viewMap` to instantiate views based on the router state. Note that we are injecting the `rootStore` into the Shell using the MobX `inject` method. If you have enabled decorators as described in the [MobX docs](https://mobx.js.org/best/decorators.html#enabling-decorators), you can use the nicer decorator syntax as we have done in MobX Shop.
+Here we instantiate the `RouterView` in the `render()` method. We supply the `routerStore` as a prop. Note that we are injecting the `rootStore` into the Shell using the MobX `inject` method. If you have enabled decorators as described in the [MobX docs](https://mobx.js.org/best/decorators.html#enabling-decorators), you can use the nicer decorator syntax as we have done in MobX Shop.
 
 The final pieces of the puzzle are the pages themselves. Here's the code for them:
 
@@ -511,16 +511,11 @@ export class StaticAdapter {
 ```
 
 ### RouterView
-The `RouterView` component watches the router state and instantiates the associated UI component. It expects two props: the `routerStore` and a `viewMap`. The `viewMap` is a simple mapping from `routeNames` to React components (or more generally `ReactNodes`).
+The `RouterView` component watches the router state and instantiates the associated UI component. It expects one prop, the `routerStore`..
 
 ```jsx
-export interface ViewMap {
-    [routeName: string]: React.ReactNode;
-}
-
 export interface RouterViewProps {
     routerStore: RouterStore;
-    viewMap: ViewMap;
 }
 
 @observer

--- a/src/components/router-view.tsx
+++ b/src/components/router-view.tsx
@@ -8,8 +8,7 @@ export interface RouterViewProps {
 
 /**
  * Watches the router state and instantiates the associated UI component.
- * It expects two props: the `routerStore` and a `viewMap`. The `viewMap`
- * is a simple mapping from `routeNames` to React components.
+ * It expects the `routerStore` as prop.
  */
 @observer
 export class RouterView extends React.Component<RouterViewProps, {}> {

--- a/src/components/router-view.tsx
+++ b/src/components/router-view.tsx
@@ -2,13 +2,8 @@ import * as React from 'react';
 import { observer } from 'mobx-react';
 import { RouterStore } from '../router-store';
 
-export interface ViewMap {
-    [routeName: string]: React.ReactNode;
-}
-
 export interface RouterViewProps {
     routerStore: RouterStore;
-    viewMap: ViewMap;
 }
 
 /**
@@ -20,14 +15,12 @@ export interface RouterViewProps {
 export class RouterView extends React.Component<RouterViewProps, {}> {
     render() {
         const {
-            routerStore: { routerState },
-            viewMap
+            routerStore: { activeView }
         } = this.props;
         // if (process.env.NODE_ENV === 'development') {
         //     console.log(`RouterView.render() - ${JSON.stringify(routerState)}`);
         // }
 
-        const view = viewMap[routerState.routeName];
-        return view ? view : null;
+        return activeView;
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export { Route, RouterState, RouterStore } from './router-store';
 
-export { ViewMap, RouterViewProps, RouterView } from './components/router-view';
+export { RouterViewProps, RouterView } from './components/router-view';
 export { Link } from './components/link';
 export { RouterLink } from './components/router-link';
 

--- a/test/generate-url.test.ts
+++ b/test/generate-url.test.ts
@@ -1,7 +1,13 @@
 import { generateUrl, routerStateToUrl } from '../src/adapters/generate-url';
-import { RouterState, RouterStore } from '../src/router-store';
+import { RouterState, RouterStore, Route } from '../src/router-store';
 
-const routes = [{ name: 'department', pattern: '/departments/:id' }];
+const routes: Route[] = [
+    {
+        name: 'department',
+        pattern: '/departments/:id',
+        component: ''
+    }
+];
 const notFound = new RouterState('notFound');
 const deptElectronics = new RouterState('department', { id: 'electronics' });
 const routerStore = new RouterStore({}, routes, notFound);

--- a/test/link.test.tsx
+++ b/test/link.test.tsx
@@ -2,12 +2,21 @@ import * as React from 'react';
 import { mount } from 'enzyme';
 import { Link } from '../src/components/link';
 import { RouterState, RouterStore } from '../src/router-store';
+import { generateComponent } from './utils';
 
 const routes = [
-    { name: 'home', pattern: '/home' },
-    { name: 'department', pattern: '/departments/:id' },
-    { name: 'items', pattern: '/items' },
-    { name: 'notFound', pattern: '/not-found' }
+    { name: 'home', pattern: '/home', component: generateComponent('home') },
+    {
+        name: 'department',
+        pattern: '/departments/:id',
+        component: generateComponent('department')
+    },
+    { name: 'items', pattern: '/items', component: generateComponent('items') },
+    {
+        name: 'notFound',
+        pattern: '/not-found',
+        component: generateComponent('notFound')
+    }
 ];
 const home = new RouterState('home');
 const notFound = new RouterState('notFound');

--- a/test/react-component.test.tsx
+++ b/test/react-component.test.tsx
@@ -1,20 +1,7 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 import { observer } from 'mobx-react';
-import { RouterState, RouterStore } from '../src/router-store';
-
-const routes = [
-    { name: 'home', pattern: '/' },
-    { name: 'department', pattern: '/departments/:id' },
-    { name: 'notFound', pattern: '/not-found' }
-];
-
-const home = new RouterState('home');
-const notFound = new RouterState('notFound');
-const dept1 = new RouterState('department', { id: 'dept1' });
-const dept2 = new RouterState('department', { id: 'dept2' });
-
-const routerStore = new RouterStore({}, routes, notFound);
+import { RouterState, RouterStore, Route } from '../src/router-store';
 
 @observer
 class DepartmentsPage extends React.Component {
@@ -48,6 +35,25 @@ class DepartmentsPage extends React.Component {
         );
     }
 }
+
+const routes: Route[] = [
+    {
+        name: 'department',
+        pattern: '/departments/:id',
+        component: <DepartmentsPage />
+    },
+    {
+        name: 'notFound',
+        pattern: '/not-found',
+        component: <h1>Not found</h1>
+    }
+];
+
+const notFound = new RouterState('notFound');
+const dept1 = new RouterState('department', { id: 'dept1' });
+const dept2 = new RouterState('department', { id: 'dept2' });
+
+const routerStore = new RouterStore({}, routes, notFound);
 
 test('DepartmentsPage changes tabs when a tab button is clicked', () => {
     // Set up router state to point to department 1

--- a/test/router-link.test.tsx
+++ b/test/router-link.test.tsx
@@ -2,12 +2,21 @@ import * as React from 'react';
 import { mount } from 'enzyme';
 import { RouterLink } from '../src/components/router-link';
 import { RouterState, RouterStore } from '../src/router-store';
+import { generateComponent } from './utils';
 
 const routes = [
-    { name: 'home', pattern: '/home' },
-    { name: 'department', pattern: '/departments/:id' },
-    { name: 'items', pattern: '/items' },
-    { name: 'notFound', pattern: '/not-found' }
+    { name: 'home', pattern: '/home', component: generateComponent('home') },
+    {
+        name: 'department',
+        pattern: '/departments/:id',
+        component: generateComponent('department')
+    },
+    { name: 'items', pattern: '/items', component: generateComponent('items') },
+    {
+        name: 'notFound',
+        pattern: '/not-found',
+        component: generateComponent('notFound')
+    }
 ];
 const home = new RouterState('home');
 const notFound = new RouterState('notFound');

--- a/test/router-store.test.tsx
+++ b/test/router-store.test.tsx
@@ -1,45 +1,72 @@
 import { Route, RouterState, RouterStore } from '../src/router-store';
+import { generateComponent } from './utils';
+
+const components = {
+    home: generateComponent('home'),
+    department: generateComponent('department'),
+    gym: generateComponent('gym'),
+    gasStation: generateComponent('gasStation'),
+    work: generateComponent('work'),
+    mountains: generateComponent('mountains'),
+    sea: generateComponent('sea'),
+    dessert: generateComponent('desert'),
+    errrorRoute: generateComponent('errorRoute'),
+    notFound: generateComponent('notFound')
+};
 
 const routes: Route[] = [
-    { name: 'home', pattern: '/' },
-    { name: 'department', pattern: '/departments/:id' },
-    { name: 'gym', pattern: '/gym' },
-    { name: 'gasStation', pattern: '/gas-station' },
-    { name: 'notFound', pattern: '/not-found' },
+    { name: 'home', pattern: '/', component: components.home },
+    {
+        name: 'department',
+        pattern: '/departments/:id',
+        component: components.department
+    },
+    { name: 'gym', pattern: '/gym', component: components.gym },
+    {
+        name: 'gasStation',
+        pattern: '/gas-station',
+        component: components.gasStation
+    },
+    { name: 'notFound', pattern: '/not-found', component: components.notFound },
     {
         name: 'work',
         pattern: '/work',
         beforeExit: fromState => {
             return Promise.reject(gym);
-        }
+        },
+        component: components.work
     },
     {
         name: 'mountains',
         pattern: '/mountains',
         beforeEnter: fromState => {
             return Promise.reject(gasStation);
-        }
+        },
+        component: components.mountains
     },
     {
         name: 'sea',
         pattern: '/sea',
         onExit: fromState => {
             return Promise.reject(gasStation);
-        }
+        },
+        component: components.sea
     },
     {
         name: 'dessert',
         pattern: '/dessert',
         onEnter: fromState => {
             return Promise.reject(gasStation);
-        }
+        },
+        component: components.dessert
     },
     {
         name: 'errorRoute',
         pattern: '/error',
         onEnter: () => {
             throw new Error('Internal error');
-        }
+        },
+        component: components.errrorRoute
     }
 ];
 
@@ -62,23 +89,25 @@ const errorState = new RouterState('errorRoute');
 
 describe('RouterStore', () => {
     test('transitions to the desired state', () => {
-        expect.assertions(2);
+        expect.assertions(3);
 
         const routerStore = new RouterStore({}, routes, notFound);
         return routerStore.goTo(home).then(toState => {
             expect(toState.isEqual(home)).toBeTruthy();
+            expect(routerStore.activeView).toEqual(components.home);
             expect(routerStore.isTransitioning).toBeFalsy();
         });
     });
 
     test('transitions to the desired state using goto overload (variation 1)', () => {
-        expect.assertions(1);
+        expect.assertions(2);
 
         const routerStore = new RouterStore({}, routes, notFound);
         return routerStore
             .goTo('department', { id: 'electronics' })
             .then(toState => {
                 expect(toState.isEqual(deptElectronics)).toBeTruthy();
+                expect(routerStore.activeView).toEqual(components.department);
             });
     });
 

--- a/test/static-adapter.test.tsx
+++ b/test/static-adapter.test.tsx
@@ -5,6 +5,7 @@ import { observable, action, runInAction } from 'mobx';
 import { StaticAdapter } from '../src/adapters/static-adapter';
 import { Route, RouterState, RouterStore } from '../src/router-store';
 import { createLocation } from 'history';
+import { generateComponent } from './utils';
 
 const itemValue = `Hello World`;
 class RootStore {
@@ -25,10 +26,15 @@ class RootStore {
 }
 
 const routes: Route[] = [
-    { name: 'home', pattern: '/' },
+    {
+        name: 'home',
+        pattern: '/',
+        component: generateComponent('home')
+    },
     {
         name: 'department',
-        pattern: '/departments/:id'
+        pattern: '/departments/:id',
+        component: generateComponent('department')
     },
     {
         name: 'beforeEnter',
@@ -36,9 +42,14 @@ const routes: Route[] = [
         beforeEnter: (fromState, toState, routerStore) => {
             const rootStore = routerStore.rootStore;
             return rootStore.loadItem();
-        }
+        },
+        component: generateComponent('beforeEnter')
     },
-    { name: 'notFound', pattern: '/not-found' }
+    {
+        name: 'notFound',
+        pattern: '/not-found',
+        component: generateComponent('notFound')
+    }
 ];
 
 const rootStore = new RootStore();

--- a/test/utils.tsx
+++ b/test/utils.tsx
@@ -1,0 +1,2 @@
+import React from 'react';
+export const generateComponent = (name: string) => <h1>{name}</h1>;


### PR DESCRIPTION
Instead of passing a viewMap, this change makes it more like react-router where you pass the component to render as property in the route configuration.

```jsx
import HomeComponent from './src/features/Home';
import DepartmentComponent from './src/features/Department';

export const routes = [
    {
        name: 'home',
        pattern: '/',
        component: HomeComponent
    },
    {
        name: 'department',
        pattern: '/departments/:id',
        component: DepartmentComponent 
    },
    {
        name: 'notFound',
        pattern: '/not-found',
        component: <h1>404 Page not found</h1>
    }
];
```

The change includes a new computed property in the routerStore, activeView, which relies on the internal viewMap thats being created in the constructor that maps the component with the route name.
