### PR TITLE
feat: provide access to History.replace

### DIFF
--- a/src/adapters/history-adapter.ts
+++ b/src/adapters/history-adapter.ts
@@ -73,7 +73,11 @@ export class HistoryAdapter {
                     routerState
                 );
                 if (currentUrl !== routerStateUrl) {
-                    this.history.push(routerStateUrl);
+                    if (routerState.options && routerState.options.replace) {
+                        this.history.replace(routerStateUrl);
+                    } else {
+                        this.history.push(routerStateUrl);
+                    }
                     // if (process.env.NODE_ENV === 'development') {
                     //     console.log(
                     //         `HistoryAdapter: history.push(${routerStateUrl}),`,

--- a/src/components/router-link.tsx
+++ b/src/components/router-link.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { inject, observer } from 'mobx-react';
-import { RouterState, StringMap } from '../router-store';
+import { RouterState, StringMap, RouterStateOptions } from '../router-store';
 import { routerStateToUrl } from '../adapters/generate-url';
 
 function isLeftClickEvent(event: React.MouseEvent<HTMLElement>) {
@@ -19,6 +19,7 @@ export interface RouterLinkProps
     queryParams?: { [key: string]: any };
     className?: string;
     activeClassName?: string;
+    options?: RouterStateOptions;
 }
 
 /**
@@ -58,13 +59,19 @@ export class RouterLink extends React.Component<RouterLinkProps, {}> {
             queryParams,
             className,
             activeClassName,
+            options,
             children,
             href, // remove from `...others`
             onClick, // remove from `...others`
             ...others
         } = this.props;
 
-        const toState = new RouterState(routeName, params, queryParams);
+        const toState = new RouterState(
+            routeName,
+            params,
+            queryParams,
+            options
+        );
 
         const isActive = routerStore.routerState.isEqual(toState);
         const joinedClassName =
@@ -97,6 +104,7 @@ export class RouterLink extends React.Component<RouterLinkProps, {}> {
             routeName,
             params,
             queryParams,
+            options,
             onClick
         } = this.props;
         const { routerStore } = rootStore;
@@ -105,6 +113,6 @@ export class RouterLink extends React.Component<RouterLinkProps, {}> {
         if (onClick) onClick(event);
 
         // Change the router state to trigger a refresh
-        return routerStore.goTo(routeName, params, queryParams);
+        return routerStore.goTo(routeName, params, queryParams, options);
     };
 }

--- a/src/router-store.ts
+++ b/src/router-store.ts
@@ -25,6 +25,14 @@ export interface JsRouterState {
 }
 
 /**
+ * Options for a RouterState instance, provide access to History replace instead of a new entry
+ * on each navigation.
+ */
+export interface RouterStateOptions {
+    replace?: boolean;
+}
+
+/**
  * Holds the state of the router. Always use the constructor to create
  * an instance. Once an instance is created, don't mutate it - create a
  * fresh instance instead.
@@ -35,11 +43,13 @@ export class RouterState {
      * @param {string} routeName, e.g. 'department'
      * @param {StringMap} params, e.g. { id: 'electronics' }
      * @param {[key: string]: any} queryParams, e.g. { q: 'apple' } or { items: ['E1', 'E2'] }
+     * @param {RouterStateOptions} options, e.g. { replace: true } to replace History entry
      */
     constructor(
         readonly routeName: string,
         readonly params: StringMap = {},
-        readonly queryParams: { [key: string]: any } = {}
+        readonly queryParams: { [key: string]: any } = {},
+        readonly options: RouterStateOptions = {}
     ) {}
 
     static create(jsRouterState: JsRouterState): RouterState {
@@ -140,16 +150,23 @@ export class RouterStore {
     goTo(
         routeName: string,
         params?: StringMap,
-        queryParams?: { [key: string]: any }
+        queryParams?: { [key: string]: any },
+        options?: RouterStateOptions
     ): Promise<RouterState>;
     goTo(
         toStateOrRouteName: RouterState | string,
         params: StringMap = {},
-        queryParams: { [key: string]: any } = {}
+        queryParams: { [key: string]: any } = {},
+        options: RouterStateOptions = {}
     ): Promise<RouterState> {
         const toState =
             typeof toStateOrRouteName === 'string'
-                ? new RouterState(toStateOrRouteName, params, queryParams)
+                ? new RouterState(
+                      toStateOrRouteName,
+                      params,
+                      queryParams,
+                      options
+                  )
                 : toStateOrRouteName;
         const fromState = this.routerState;
         return this.transition(fromState, toState);


### PR DESCRIPTION
Add simple `RouterStateOptions` to distinguish state transitions that should replace the history element instead of adding a new one, so that applications may avoid adding needless browser back button navigations as necessary.