### PR TITLE
Update to latest versions of mobx 6 and react; update examples

### DIFF
--- a/examples/mobx-shop/src/stores/AuthStore.ts
+++ b/examples/mobx-shop/src/stores/AuthStore.ts
@@ -22,6 +22,13 @@ export class AuthStore {
             setSignInRedirect: action,
         });
         this.rootStore = rootStore;
+        makeObservable(this, {
+            user: observable.ref,
+            signInRedirect: observable.ref,
+            setUser: action,
+            clearUser: action,
+            setSignInRedirect: action,
+        });
     }
 
     setUser = (user: User) => {

--- a/examples/mobx-shop/src/stores/CartStore.ts
+++ b/examples/mobx-shop/src/stores/CartStore.ts
@@ -19,6 +19,11 @@ export class CartStore {
             clearCart: action,
         });
         this.rootStore = rootStore;
+        makeObservable(this, {
+            total: computed,
+            addOrder: action,
+            clearCart: action,
+        });
     }
 
     get total() {

--- a/examples/mobx-shop/src/stores/ItemStore.ts
+++ b/examples/mobx-shop/src/stores/ItemStore.ts
@@ -16,6 +16,12 @@ export class ItemStore {
             setSelectedItem: action,
         });
         this.rootStore = rootStore;
+        makeObservable(this, {
+            selectedItem: observable.ref,
+            setItems: action,
+            clearItems: action,
+            setSelectedItem: action,
+        });
     }
 
     setItems(items: Array<Item>) {

--- a/examples/mobx-shop/src/stores/PrefStore.ts
+++ b/examples/mobx-shop/src/stores/PrefStore.ts
@@ -19,6 +19,12 @@ export class PrefStore {
             toggleTheme: action,
         });
         this.rootStore = rootStore;
+        makeObservable(this, {
+            paletteType: observable,
+            theme: computed,
+            loadFromStorage: action,
+            toggleTheme: action,
+        });
     }
 
     // ----- Load from storage -----

--- a/examples/ssr/src/stores/ItemStore.ts
+++ b/examples/ssr/src/stores/ItemStore.ts
@@ -17,6 +17,12 @@ export class ItemStore {
         });
         this.rootStore = rootStore;
         this.handleLoaded(items);
+        makeObservable(this, {
+            loading: observable,
+            items: observable.ref,
+            handleStartLoading: action,
+            handleLoaded: action,
+        });
     }
 
     handleStartLoading() {

--- a/examples/ssr/src/stores/RepoStore.ts
+++ b/examples/ssr/src/stores/RepoStore.ts
@@ -17,6 +17,12 @@ export class RepoStore {
         });
         this.rootStore = rootStore;
         this.handleLoaded(repos);
+        makeObservable(this, {
+            loading: observable,
+            repos: observable.ref,
+            handleStartLoading: action,
+            handleLoaded: action,
+        });
     }
 
     handleStartLoading() {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "peerDependencies": {
         "mobx": ">=6",
         "mobx-react-lite": ">=3",
-        "react": ">=16"
+        "react": ">=16.8"
     },
     "devDependencies": {
         "@commitlint/cli": "^11.0.0",
@@ -56,8 +56,8 @@
         "@types/debug": "^4.1.5",
         "@types/history": "^4.7.8",
         "@types/query-string": "^6.3.0",
-        "@types/react": "^16.9.51",
-        "@types/react-dom": "^16.9.8",
+        "@types/react": "^16.9.56",
+        "@types/react-dom": "^16.9.9",
         "@typescript-eslint/eslint-plugin": "^4.4.0",
         "babel-eslint": "10.1.0",
         "commitizen": "^4.2.1",
@@ -70,14 +70,14 @@
         "eslint-plugin-react-hooks": "^4.1.2",
         "eslint-plugin-testing-library": "^3.9.0",
         "husky": "^4.3.0",
-        "mobx": "^6.0.1",
-        "mobx-react-lite": "^3.0.0",
+        "mobx": "^6.0.4",
+        "mobx-react-lite": "^3.1.6",
         "prettier": "^2.1.2",
-        "react": "^16.13.1",
-        "react-dom": "^16.13.1",
+        "react": "^17.0.1",
+        "react-dom": "^17.0.1",
         "tsdx": "^0.14.0",
         "tslib": "^2.0.2",
-        "typescript": "^4.0.3"
+        "typescript": "^4.0.5"
     },
     "husky": {
         "hooks": {

--- a/src/components/RouterView.tsx
+++ b/src/components/RouterView.tsx
@@ -1,6 +1,6 @@
 import Debug from 'debug';
 import { observer } from 'mobx-react-lite';
-import React, { Fragment } from 'react';
+import React from 'react';
 import { useRouterStore } from '../contexts';
 
 const debug = Debug('msr:RouterView');
@@ -24,5 +24,5 @@ export const RouterView: React.FC<RouterViewProps> = observer(({ viewMap }) => {
     debug('render %o', routerState);
 
     const view = viewMap[routerState.routeName];
-    return view ? <Fragment>{view}</Fragment> : null;
+    return view ? <>{view}</> : null;
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1527,17 +1527,25 @@
   dependencies:
     query-string "*"
 
-"@types/react-dom@^16.9.8":
-  version "16.9.8"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.8.tgz#fe4c1e11dfc67155733dfa6aa65108b4971cb423"
-  integrity sha512-ykkPQ+5nFknnlU6lDd947WbQ6TE3NNzbQAkInC2EKY1qeYdTKp7onFusmYZb+ityzx2YviqT6BXSu+LyWWJwcA==
+"@types/react-dom@^16.9.9":
+  version "16.9.9"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.9.tgz#d2d0a6f720a0206369ccbefff752ba37b9583136"
+  integrity sha512-jE16FNWO3Logq/Lf+yvEAjKzhpST/Eac8EMd1i4dgZdMczfgqC8EjpxwNgEe3SExHYLliabXDh9DEhhqnlXJhg==
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^16.9.51":
+"@types/react@*":
   version "16.9.51"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.51.tgz#f8aa51ffa9996f1387f63686696d9b59713d2b60"
   integrity sha512-lQa12IyO+DMlnSZ3+AGHRUiUcpK47aakMMoBG8f7HGxJT8Yfe+WE128HIXaHOHVPReAW0oDS3KAI0JI2DDe1PQ==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^3.0.2"
+
+"@types/react@^16.9.56":
+  version "16.9.56"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.56.tgz#ea25847b53c5bec064933095fc366b1462e2adf0"
+  integrity sha512-gIkl4J44G/qxbuC6r2Xh+D3CGZpJ+NdWTItAPmZbR5mUS+JQ8Zvzpl0ea5qT/ZT3ZNTUcDKUVqV3xBE8wv/DyQ==
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"
@@ -5233,15 +5241,15 @@ mkdirp@0.x, mkdirp@^0.5.1:
   dependencies:
     minimist "^1.2.5"
 
-mobx-react-lite@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/mobx-react-lite/-/mobx-react-lite-3.0.0.tgz#f39b1cb23262ce539829d47217551e04bf14a8b7"
-  integrity sha512-SJgrTD9mfClFOsamB+0y6zjteSMr4gkp9usnpIeEi8E+lW3lMgDa3hnD4PJgLGoENpJ8/9OmO3vrkA50SNy0mw==
+mobx-react-lite@^3.1.6:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/mobx-react-lite/-/mobx-react-lite-3.1.6.tgz#e7f4809ab66edd1acca5adb00c6b88c600ae1952"
+  integrity sha512-MM3x9BLt5nC7iE/ILA5n2+hfrplEKYbFjqROEuGkzBdZP/KD+Z44+2gseczRrTG0xFuiPWfEzgT68+6/zqOiEw==
 
-mobx@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/mobx/-/mobx-6.0.1.tgz#ec23520848527bf7834d7b4c0b54b2a8eb6e7c14"
-  integrity sha512-Pk6uJXZ34yqd661yRmS6z/9avm4FOGXpFpVjnEfiYYOsZXnAxv1fpYjxTCEZ9tuwk0Xe1qnUUlgm+rJtGe0YJA==
+mobx@^6.0.4:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/mobx/-/mobx-6.0.4.tgz#8fc3e3629a3346f8afddf5bd954411974744dad1"
+  integrity sha512-wT2QJT9tW19VSHo9x7RPKU3z/I2Ps6wUS8Kb1OO+kzmg7UY3n4AkcaYG6jq95Lp1R9ohjC/NGYuT2PtuvBjhFg==
 
 mri@^1.1.0:
   version "1.1.6"
@@ -5810,7 +5818,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.4"
 
-prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -5868,29 +5876,27 @@ randombytes@^2.1.0:
   dependencies:
     safe-buffer "^5.1.0"
 
-react-dom@^16.13.1:
-  version "16.13.1"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"
-  integrity sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==
+react-dom@^17.0.1:
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.1.tgz#1de2560474ec9f0e334285662ede52dbc5426fc6"
+  integrity sha512-6eV150oJZ9U2t9svnsspTMrWNyHc6chX0KzDeAOXftRa8bNeOKTTfCJ7KorIwenkHd2xqVTBTCZd79yk/lx/Ug==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.19.1"
+    scheduler "^0.20.1"
 
 react-is@^16.12.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react@^16.13.1:
-  version "16.13.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
-  integrity sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==
+react@^17.0.1:
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-17.0.1.tgz#6e0600416bd57574e3f86d92edba3d9008726127"
+  integrity sha512-lG9c9UuMHdcAexXtigOZLX8exLWkW0Ku29qPRU8uhF2R9BN96dLCt0psvzPLlHc5OWkgymP3qwTRgbnw5BKx3w==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.2"
 
 read-pkg-up@^2.0.0:
   version "2.0.0"
@@ -6331,10 +6337,10 @@ saxes@^3.1.9:
   dependencies:
     xmlchars "^2.1.1"
 
-scheduler@^0.19.1:
-  version "0.19.1"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
-  integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
+scheduler@^0.20.1:
+  version "0.20.1"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.1.tgz#da0b907e24026b01181ecbc75efdc7f27b5a000c"
+  integrity sha512-LKTe+2xNJBNxu/QhHvDR14wUXHRQbVY5ZOYpOGWRzhydZUqrLb2JBvLPY7cAqFmqrWuDED0Mjk7013SZiOz6Bw==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -7150,10 +7156,10 @@ typescript@^3.7.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
-typescript@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.3.tgz#153bbd468ef07725c1df9c77e8b453f8d36abba5"
-  integrity sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==
+typescript@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.5.tgz#ae9dddfd1069f1cb5beb3ef3b2170dd7c1332389"
+  integrity sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
I was just about to submit a PR to migrate `mobx-state-router` to mobx 6, but then I saw that there was already a branch in progress for this work.  I merged my branch into the existing `mobx6-update` branch and thought I'd contribute the diff anyway in case it helps.  The main changes here are:

* Updated to the most recent versions of `mobx`, `mobx-react-lite`, `react`, and `typescript`
* Updated the examples for mobx 6+
* Minor simplification in `RouterView`